### PR TITLE
Add 90-day roadmap issue drafts

### DIFF
--- a/.github/ISSUE_DRAFTS/01-stabilize-ci.md
+++ b/.github/ISSUE_DRAFTS/01-stabilize-ci.md
@@ -1,0 +1,23 @@
+Title: Stabilize CI & expand test matrix
+Labels: infra, ci
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Ensure the repository CI reliably builds the solution and runs the tests on both Windows and Ubuntu runners. Add a minimal matrix entry for OS and consider adding a .NET SDK matrix entry if stable.
+
+Deliverables
+----
+- Update `.github/workflows/ci.yml` to include an Ubuntu runner and a minimal matrix (OS: windows-latest, ubuntu-latest).
+- Confirm `dotnet build` and `dotnet test` succeed on both runners.
+- Add short docs in `docs/` for CI expectations.
+
+Success criteria
+----
+- CI runs green on Windows and Ubuntu for the default test suite.
+- Any flaky tests are documented or temporarily quarantined with a linked follow-up issue.
+
+Notes / commands
+----
+Use the existing build steps documented in `docs/ROADMAP.md` as the starting point. If bandwidth is limited, start with Ubuntu + your current Windows runner and expand later.

--- a/.github/ISSUE_DRAFTS/02-core-adapters-contracts.md
+++ b/.github/ISSUE_DRAFTS/02-core-adapters-contracts.md
@@ -1,0 +1,23 @@
+Title: Finalize Core/Adapter contracts & remove domain leakage
+Labels: core, refactor
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Ensure UI projects (Avalonia/Editor) do not directly reference domain types from `DotGame.Core`. All core services should be provided via interfaces defined in `DotGame.Core`.
+
+Deliverables
+----
+- Audit UI projects for any remaining `using DotGame.Core` or direct domain type references.
+- Migrate remaining references to adapter interfaces (add small adapter shims where necessary).
+- Add or update CI lint rules and verify no regressions.
+
+Success criteria
+----
+- CI lint rule passes: no files in UI projects declare `namespace DotGame.Core`.
+- All preview- and tile-related code paths use `DotGame.Core` interfaces.
+
+Notes
+----
+This is low-risk refactoring; prefer small PRs to keep reviews manageable.

--- a/.github/ISSUE_DRAFTS/03-preview-tests.md
+++ b/.github/ISSUE_DRAFTS/03-preview-tests.md
@@ -1,0 +1,22 @@
+Title: Editor preview robustness & test coverage
+Labels: tests, preview
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Increase test coverage around the preview lifecycle. Add tests that exercise starting from JSON, concurrent start/stop, and error handling in headless and EditorWindow contexts.
+
+Deliverables
+----
+- Add 4–6 tests in `DotGame.Tests` and/or `DotGame.Core.Tests` covering start/stop/error cases.
+- Create a small test helper for generating serialized maps used in tests.
+
+Success criteria
+----
+- New tests pass locally and in CI.
+- The preview-related code path has at least 80% coverage on critical methods (goal, not hard requirement).
+
+Notes
+----
+Prefer headless adapters and mocks to avoid unreliable UI dependencies in CI.

--- a/.github/ISSUE_DRAFTS/04-avalonia-migration.md
+++ b/.github/ISSUE_DRAFTS/04-avalonia-migration.md
@@ -1,0 +1,19 @@
+Title: UX & Avalonia migration sprint
+Labels: ui, avalonia, ux
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Convert the remaining Windows Forms dialogs to Avalonia and ensure the main editor workflows work on Avalonia without platform fallbacks.
+
+Deliverables
+----
+- Identify 2–4 remaining dialogs or UI bits still on WinForms.
+- Convert them to Avalonia with matching behavior and tests where possible.
+- Update `docs/` with migration notes and screenshots.
+
+Success criteria
+----
+- Manual regression: start/stop preview, open/save map, and tile editing work on Avalonia.
+- No new platform-specific code paths required for the converted dialogs.

--- a/.github/ISSUE_DRAFTS/05-asset-pipeline.md
+++ b/.github/ISSUE_DRAFTS/05-asset-pipeline.md
@@ -1,0 +1,21 @@
+Title: Asset & tile pipeline improvements
+Labels: assets, tools
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Make it easier for contributors to add tilesets and validate assets before running the editor. Provide small tooling and documentation for the asset layout.
+
+Deliverables
+----
+- A small validation script in `scripts/` that checks a tileset for expected metadata and image sizes.
+- Documentation in `docs/` describing the asset layout and contributor flow.
+
+Success criteria
+----
+- Contributors can run the validation script and receive clear pass/fail output with actionable messages.
+
+Notes
+----
+Start with a Python or PowerShell script depending on contributor preference; keep the dependencies minimal.

--- a/.github/ISSUE_DRAFTS/90-day-milestone.md
+++ b/.github/ISSUE_DRAFTS/90-day-milestone.md
@@ -1,0 +1,21 @@
+---
+title: "90-day plan: Oct 24 2025 — Jan 22 2026"
+description: "Milestone grouping the 90-day actionable roadmap items from docs/ROADMAP.md"
+due_date: 2026-01-22
+labels:
+  - roadmap
+  - milestone
+owners: [project-lead]
+---
+
+This milestone groups the small, testable items that implement the `docs/ROADMAP.md` "Next 90 days (actionable)" plan.
+
+Included issues:
+- Stabilize CI & expand test matrix
+- Finalize Core/Adapter contracts & reduce domain leakage
+- Editor preview robustness & test coverage
+- UX & Avalonia migration sprint
+- Asset & tile pipeline improvements
+
+Notes:
+- Create each issue from the corresponding draft file in this folder and assign owners/labels per team conventions.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,3 +113,53 @@ Notes: unit tests include headless-friendly tests that initialize Avalonia's Ski
 
 This file is intended to be a concise snapshot of progress. The authoritative, machine-readable source of task state is the repository todo list (maintained during development). Update that list first and then refresh this document when the plan changes.
 
+---
+
+## Next 90 days (actionable)
+
+This section translates the current work plan into a focused, testable 90-day execution plan with owners, estimated milestones, and success criteria. Each item below is intentionally small and verifiable — when complete, convert it into issues/milestones in GitHub.
+
+1) Stabilize CI & expand test matrix — Owner: infra / core maintainer (week 0–3)
+   - Goal: Ensure solution builds and tests run on Windows and Linux in CI; add a minimal matrix for .NET 8 and .NET 7 compatibility if feasible.
+   - Deliverables: updated `.github/workflows/ci.yml` with matrix entries, passing runs for both OSes.
+   - Success criteria: CI green on both Windows and Ubuntu runners for the default test suite within 3 attempts.
+
+2) Finalize Core/Adapter contracts & reduce domain leakage — Owner: core maintainer (week 1–6)
+   - Goal: Remove remaining direct domain type references from UI projects; ensure all core services are referenced via interfaces in `DotGame.Core`.
+   - Deliverables: linter rule verification, PR to update any remaining references, small migration notes in `docs/`.
+   - Success criteria: No files in UI projects using `namespace DotGame.Core` per CI lint; tests covering preview startup/shutdown pass.
+
+3) Editor preview robustness & test coverage — Owner: runtime/editor dev (week 2–8)
+   - Goal: Increase test coverage around preview lifecycle, add edge tests for starting previews from JSON strings and concurrent start/stop calls.
+   - Deliverables: 4–6 new unit/integration tests added to `DotGame.Tests` and `DotGame.Core.Tests` covering startup, stop, and error conditions.
+   - Success criteria: Added tests pass locally and in CI; code paths for preview error handling exercised by tests.
+
+4) UX & Avalonia migration sprint — Owner: UI/UX dev (week 4–12)
+   - Goal: Convert the last 2–4 remaining Windows Forms dialogs to Avalonia and remove any platform-specific fallbacks.
+   - Deliverables: PR(s) converting dialogs, updated screenshots in `docs/`, and a short contributor note on registering adapters.
+   - Success criteria: All editor workflows exercised manually (start/stop preview, open/save map, tile editing) work on Avalonia without crashing.
+
+5) Asset & tile pipeline improvements — Owner: asset lead (week 6–12)
+   - Goal: Simplify creating/previewing maps and tiles in the editor and reduce friction for contributors adding assets.
+   - Deliverables: small CLI or script (`scripts/`) to validate tilesets, and documentation in `docs/` describing the asset layout.
+   - Success criteria: Contributors can add a tileset and run a validation script that returns pass/fail with actionable messages.
+
+6) Convert roadmap items to issues & set milestones — Owner: project lead (week 0–2)
+   - Goal: Create GitHub issues for the above items, assign owners, and set a 90-day milestone so progress is tracked in the issue tracker.
+   - Deliverables: issues created with checklists, milestone created for the 90-day plan.
+   - Success criteria: Each of the 1–5 items has an issue and the milestone is populated.
+
+Quick notes and assumptions
+--
+- Assumes maintainers have permissions to change GitHub workflows and create milestones.
+- If running matrix CI is too heavy, start with a single Ubuntu runner and expand after stability is confirmed.
+- Tests that depend on graphical components should prefer headless adapters or be ignored for headful runners.
+
+Next actions (recommended)
+- Convert each numbered item above into an issue and attach this section as an implementation note.
+- Triage the infra tasks first (CI + milestone creation) so contributors can rely on consistent validation.
+
+---
+
+Update history: 2025-10-24 — appended actionable 90-day plan.
+


### PR DESCRIPTION
Adds .github/ISSUE_DRAFTS with milestone and issue drafts for maintainers to import.