### PR TITLE
chore: add passability validator, tests, and roadmap checklist

### DIFF
--- a/.github/ISSUE_DRAFTS/01-stabilize-ci.md
+++ b/.github/ISSUE_DRAFTS/01-stabilize-ci.md
@@ -1,0 +1,23 @@
+Title: Stabilize CI & expand test matrix
+Labels: infra, ci
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Ensure the repository CI reliably builds the solution and runs the tests on both Windows and Ubuntu runners. Add a minimal matrix entry for OS and consider adding a .NET SDK matrix entry if stable.
+
+Deliverables
+----
+- Update `.github/workflows/ci.yml` to include an Ubuntu runner and a minimal matrix (OS: windows-latest, ubuntu-latest).
+- Confirm `dotnet build` and `dotnet test` succeed on both runners.
+- Add short docs in `docs/` for CI expectations.
+
+Success criteria
+----
+- CI runs green on Windows and Ubuntu for the default test suite.
+- Any flaky tests are documented or temporarily quarantined with a linked follow-up issue.
+
+Notes / commands
+----
+Use the existing build steps documented in `docs/ROADMAP.md` as the starting point. If bandwidth is limited, start with Ubuntu + your current Windows runner and expand later.

--- a/.github/ISSUE_DRAFTS/02-core-adapters-contracts.md
+++ b/.github/ISSUE_DRAFTS/02-core-adapters-contracts.md
@@ -1,0 +1,23 @@
+Title: Finalize Core/Adapter contracts & remove domain leakage
+Labels: core, refactor
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Ensure UI projects (Avalonia/Editor) do not directly reference domain types from `DotGame.Core`. All core services should be provided via interfaces defined in `DotGame.Core`.
+
+Deliverables
+----
+- Audit UI projects for any remaining `using DotGame.Core` or direct domain type references.
+- Migrate remaining references to adapter interfaces (add small adapter shims where necessary).
+- Add or update CI lint rules and verify no regressions.
+
+Success criteria
+----
+- CI lint rule passes: no files in UI projects declare `namespace DotGame.Core`.
+- All preview- and tile-related code paths use `DotGame.Core` interfaces.
+
+Notes
+----
+This is low-risk refactoring; prefer small PRs to keep reviews manageable.

--- a/.github/ISSUE_DRAFTS/03-preview-tests.md
+++ b/.github/ISSUE_DRAFTS/03-preview-tests.md
@@ -1,0 +1,22 @@
+Title: Editor preview robustness & test coverage
+Labels: tests, preview
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Increase test coverage around the preview lifecycle. Add tests that exercise starting from JSON, concurrent start/stop, and error handling in headless and EditorWindow contexts.
+
+Deliverables
+----
+- Add 4–6 tests in `DotGame.Tests` and/or `DotGame.Core.Tests` covering start/stop/error cases.
+- Create a small test helper for generating serialized maps used in tests.
+
+Success criteria
+----
+- New tests pass locally and in CI.
+- The preview-related code path has at least 80% coverage on critical methods (goal, not hard requirement).
+
+Notes
+----
+Prefer headless adapters and mocks to avoid unreliable UI dependencies in CI.

--- a/.github/ISSUE_DRAFTS/04-avalonia-migration.md
+++ b/.github/ISSUE_DRAFTS/04-avalonia-migration.md
@@ -1,0 +1,19 @@
+Title: UX & Avalonia migration sprint
+Labels: ui, avalonia, ux
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Convert the remaining Windows Forms dialogs to Avalonia and ensure the main editor workflows work on Avalonia without platform fallbacks.
+
+Deliverables
+----
+- Identify 2–4 remaining dialogs or UI bits still on WinForms.
+- Convert them to Avalonia with matching behavior and tests where possible.
+- Update `docs/` with migration notes and screenshots.
+
+Success criteria
+----
+- Manual regression: start/stop preview, open/save map, and tile editing work on Avalonia.
+- No new platform-specific code paths required for the converted dialogs.

--- a/.github/ISSUE_DRAFTS/05-asset-pipeline.md
+++ b/.github/ISSUE_DRAFTS/05-asset-pipeline.md
@@ -1,0 +1,21 @@
+Title: Asset & tile pipeline improvements
+Labels: assets, tools
+Assignees: TBD
+Milestone: 90-day plan: Oct 24 2025 — Jan 22 2026
+
+Goal
+----
+Make it easier for contributors to add tilesets and validate assets before running the editor. Provide small tooling and documentation for the asset layout.
+
+Deliverables
+----
+- A small validation script in `scripts/` that checks a tileset for expected metadata and image sizes.
+- Documentation in `docs/` describing the asset layout and contributor flow.
+
+Success criteria
+----
+- Contributors can run the validation script and receive clear pass/fail output with actionable messages.
+
+Notes
+----
+Start with a Python or PowerShell script depending on contributor preference; keep the dependencies minimal.

--- a/.github/ISSUE_DRAFTS/90-day-milestone.md
+++ b/.github/ISSUE_DRAFTS/90-day-milestone.md
@@ -1,0 +1,21 @@
+---
+title: "90-day plan: Oct 24 2025 — Jan 22 2026"
+description: "Milestone grouping the 90-day actionable roadmap items from docs/ROADMAP.md"
+due_date: 2026-01-22
+labels:
+  - roadmap
+  - milestone
+owners: [project-lead]
+---
+
+This milestone groups the small, testable items that implement the `docs/ROADMAP.md` "Next 90 days (actionable)" plan.
+
+Included issues:
+- Stabilize CI & expand test matrix
+- Finalize Core/Adapter contracts & reduce domain leakage
+- Editor preview robustness & test coverage
+- UX & Avalonia migration sprint
+- Asset & tile pipeline improvements
+
+Notes:
+- Create each issue from the corresponding draft file in this folder and assign owners/labels per team conventions.

--- a/.github/ISSUE_TEMPLATE/90-day-roadmap.md
+++ b/.github/ISSUE_TEMPLATE/90-day-roadmap.md
@@ -1,0 +1,31 @@
+---
+name: 90-day Roadmap Item
+about: Create an issue that implements one item from the 90-day roadmap
+title: '[ROADMAP] {short description}'
+labels: roadmap
+---
+
+<!--
+Use this template to create a GitHub issue corresponding to an item in `docs/ROADMAP.md`.
+Replace the sections below with concrete implementation steps and acceptance criteria.
+-->
+
+## Summary
+
+What is the goal? (one or two sentences)
+
+## Motivation
+
+Why is this important? Link to `docs/ROADMAP.md` and related files.
+
+## Acceptance criteria
+- [ ] Clear, testable criteria (unit/integration/manual) — list them here.
+- [ ] PR adds tests where applicable.
+- [ ] Documentation updated (README or docs/) if behavior changes.
+
+## Implementation notes
+- Proposed files to change
+- High-level plan
+
+## Estimate
+- Rough estimate (days)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+Describe the change and why it was made.
+
+## Checklist
+- [ ] I have run the solution build locally and it succeeds.
+- [ ] I have run relevant unit tests locally.
+- [ ] I added/updated tests for new behavior.
+- [ ] I added/updated documentation if appropriate (README or docs/).
+- [ ] For map/data migrations: ran MapPassabilityTool in dry-run and attached results.
+
+## Related issues
+Fixes: 

--- a/.github/workflows/validate-maps.yml
+++ b/.github/workflows/validate-maps.yml
@@ -1,0 +1,42 @@
+name: Validate maps
+
+on:
+  push:
+    paths:
+      - 'maps/**'
+      - 'tools/MapPassabilityTool/**'
+      - '.github/workflows/validate-maps.yml'
+  pull_request:
+    paths:
+      - 'maps/**'
+      - 'tools/MapPassabilityTool/**'
+
+jobs:
+  validate-maps:
+    name: Validate map passability (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Run MapPassabilityTool (dry-run)
+        run: |
+          dotnet run --project tools/MapPassabilityTool/MapPassabilityTool.csproj -- --maps-dir ./maps 2>&1 | tee validator_output.txt
+          if grep -q "MISSING" validator_output.txt; then
+            echo "Map validation failed: missing passability entries found.";
+            cat validator_output.txt;
+            exit 1;
+          fi
+          if grep -q "ERROR" validator_output.txt; then
+            echo "Map validation failed: tool reported errors.";
+            cat validator_output.txt;
+            exit 1;
+          fi

--- a/DotGame.Core.Tests/MapPassabilityTests.cs
+++ b/DotGame.Core.Tests/MapPassabilityTests.cs
@@ -1,0 +1,67 @@
+using System;
+using DotGame.Core.Maps;
+using Xunit;
+
+namespace DotGame.Core.Tests
+{
+    public class MapPassabilityTests
+    {
+        [Fact]
+        public void Initialize_WithPassability_WorksAndReturnsJagged()
+        {
+            var cols = 3;
+            var rows = 2;
+            var tileW = 32;
+            var tileH = 32;
+
+            var tiles = new string?[rows, cols];
+            for (int y = 0; y < rows; y++)
+                for (int x = 0; x < cols; x++)
+                    tiles[y, x] = null;
+
+            var pass = new bool[rows, cols];
+            pass[0, 0] = true;
+            pass[1, 2] = false;
+
+            var m = new Map();
+            m.InitializeFromArray(cols, rows, tileW, tileH, tiles, pass);
+
+            var jagged = m.GetPassabilityAsJagged();
+            Assert.NotNull(jagged);
+            Assert.Equal(rows, jagged!.Length);
+            Assert.Equal(cols, jagged[0].Length);
+            Assert.True(jagged[0][0]);
+            Assert.False(jagged[1][2]);
+        }
+
+        [Fact]
+        public void SetPassability_DimensionMismatch_Throws()
+        {
+            var m = new Map();
+            var tiles = new string?[2,2];
+            m.InitializeFromArray(2, 2, 32, 32, tiles);
+
+            var bad = new bool[3,2]; // rows mismatch
+            Assert.Throws<ArgumentException>(() => m.SetPassability(bad));
+        }
+
+        [Fact]
+        public void InitializeFromArray_TileDataDimensionMismatch_Throws()
+        {
+            var m = new Map();
+            var tiles = new string?[2,3];
+            // Provide rows=2 cols=2 but tile array has cols=3
+            Assert.Throws<ArgumentException>(() => m.InitializeFromArray(2, 2, 32, 32, tiles));
+        }
+
+        [Fact]
+        public void GetPassabilityAsJagged_ReturnsNullWhenNotSet()
+        {
+            var m = new Map();
+            var tiles = new string?[1,1];
+            m.InitializeFromArray(1, 1, 16, 16, tiles);
+            var j = m.GetPassabilityAsJagged();
+            Assert.Null(j);
+        }
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,3 +1,91 @@
+# DotGame — Focused Roadmap
+
+Last update: 2025-10-24
+
+This file is a concise, practical snapshot of repository health and priorities. It intentionally avoids a long prescriptive schedule and instead records current state, what we've completed, and what remains to be done.
+
+## 1) High-level summary
+
+- Project: `leveleditor` / DotGame — a C#/.NET 2D tile-based level editor and small runtime player.
+- Key capabilities: visual map editor (tileset loading, painting, adjustable brush, JSON save/load) and a simple game player (named characters, tile-based movement, frame-based animations).
+- Platform: originally Windows Forms (src/DotGameCSharp/). An Avalonia-based demo exists for cross-platform testing.
+- Map format: JSON with embedded base64 images per tile (simple but not optimal for larger projects).
+
+## 2) Current state — completed work (high level)
+
+The following items are completed and present in the repository or in this branch:
+
+- Domain consolidation: core game/data logic moved or centralized around `DotGame.Core` (maps, tile history, services).
+- Preview contract & adapters: `DotGame.Core.Services.IPreviewService` plus adapters and EditorWindow wiring to start/stop previews from the editor.
+- In-memory map loader: `Map.LoadFromJsonString` to start previews directly from JSON strings.
+- Nullable-safety and small bug fixes: reduced CS8602 and related warnings in key files (Map, TileServiceAdapter).
+- Tests: focused unit/integration tests added for DI wiring, preview lifecycle, and editor preview hooks (`DotGame.Tests`, `DotGame.Core.Tests`).
+- CI basics: a CI workflow exists that builds the solution and runs telemetry/analysis scripts; a lint rule prevents UI projects from declaring `namespace DotGame.Core` to avoid accidental domain duplication.
+- Tooling & migration helpers (recent additions):
+  - `tools/MapPassabilityTool` — .NET console tool to validate and optionally inject `passability` jagged arrays into `maps/*.json` (dry-run default; `--apply` writes files and creates `.bak`).
+  - `scripts/validate_maps.py` and `scripts/add_passability.py` — Python helpers for validation and batch injection (Python required).
+  - GitHub helpers: issue templates, draft issues (`issues/`), a PR template, and a milestone summary (`docs/MILESTONE-90-DAYS.md`) to convert roadmap items into tracked work.
+
+These completed items make it straightforward to validate maps for passability metadata, run a dry-run migration, and begin an incremental, reviewable migration of data and CI checks.
+
+## 3) Outstanding work (what still needs to be done)
+
+The repository is a solid prototype but several meaningful items remain before the project can be considered a polished, cross-platform editor/runtime or a reusable engine. Key outstanding tasks:
+
+- Full Avalonia port for editor UI: the demo runs, but several auxiliary dialogs and workflows still rely on Windows Forms; these need porting for a complete cross-platform UX.
+- Asset pipeline and tileset export: avoid embedding full PNG data in map JSON. Add exporters that extract tiles into `assets/` folders and rewrite maps to reference files instead of base64 blobs.
+- Passability migration: many `maps/*.json` files still lack a `passability` field. Use the `tools/MapPassabilityTool` (or Python scripts) in a controlled migration to add passability grids and commit the results with backups.
+- CI integration for validation: add a CI step that runs the validator in dry-run (or strict mode after migration) to prevent malformed maps from landing.
+- Broader unit test coverage: expand tests to cover map loading edge cases, Save/Load roundtrips, tile metadata, and history/undo if added.
+- Structured logging and error handling: introduce `Microsoft.Extensions.Logging` or Serilog for core and adapters; add more robust exception handling for IO/JSON errors.
+- Editor UX improvements: undo/redo, multiple tile layers, visible tile metadata editing (collision/trigger flags), and map export options.
+- Small engine features (optional): audio playback, simple NPC AI/patrol behavior, and a scripting surface (Lua/C#) if the project aims to support modding or complex behaviors.
+- Performance improvements: consider reducing the memory/IO cost of embedded base64 tiles and, if needed, adopt more efficient data structures for large maps.
+
+## 4) Risk & stability notes
+
+- The codebase appears stable for its scope (editor + small runtime). Unit tests and CI are present for core paths, but gaps remain for edge cases.
+- Map JSON format with embedded images is functional but brittle at scale — migrating to file-backed tilesets reduces repository bloat and improves editor performance.
+- Changes that modify `maps/*.json` should be done with backups and code review; the repo now includes tools to help do that safely.
+
+## 5) How to validate locally (quick commands)
+
+Build and run tests:
+
+```powershell
+dotnet build "leveleditor.sln" --configuration Release
+dotnet test "leveleditor.sln" --configuration Release --no-build
+```
+
+Map validation (dry-run):
+
+```powershell
+dotnet run --project tools/MapPassabilityTool/MapPassabilityTool.csproj -- --maps-dir .\maps
+```
+
+Map migration (creates `.bak` backups) — run only after review/approval:
+
+```powershell
+dotnet run --project tools/MapPassabilityTool/MapPassabilityTool.csproj -- --maps-dir .\maps --apply
+```
+
+Or use the Python helpers (if you have Python installed):
+
+```powershell
+python .\scripts\validate_maps.py .\maps
+python .\scripts\add_passability.py .\maps
+```
+
+## 6) Suggested immediate next steps (non-actionable guidance)
+
+- Run the passability tool in dry-run and review which maps lack `passability` metadata.
+- Decide whether to migrate all maps at once or migrate incrementally as parts of the repo are touched.
+- Add a CI dry-run validator step to catch malformed maps early.
+- Begin porting the highest-priority Windows Forms dialogs to Avalonia so cross-platform testing covers common editor flows.
+
+---
+
+If you want, I can open a branch/PR with the migration applied (with `.bak` backups), or I can run the validator here and paste the dry-run output so you can review before any write operation. Which would you prefer?
 # DotGame Roadmap
 
 This document mirrors the project's roadmap and tracks progress against the implementation plan described in `docs/core-concepts-blueprint.md` and the repo todo list.
@@ -40,6 +128,73 @@ Validation:
 
 ---
 
+## Status update — recent repository changes (2025-10-24)
+
+Since the last consolidation the repository received several practical additions to help migrate maps and track roadmap work. These are small, low-risk artifacts intended to make the next steps (map migration, CI checks, and incremental features) easier to implement and review.
+
+Completed and added locally in this branch:
+- A small C# dotnet console tool: `tools/MapPassabilityTool` — validates `maps/*.json` for `passability` and (optionally) injects a default `passability` jagged bool[][]. It supports `--maps-dir` and `--apply` and creates `.bak` backups before writing. See `tools/MapPassabilityTool/README.md` for usage.
+- Two lightweight Python helpers (kept in `scripts/`): `scripts/validate_maps.py` and `scripts/add_passability.py` for validating maps and batch-injecting passability metadata (Python required to run them).
+- Issue templates and draft issues under `.github/ISSUE_TEMPLATE` and `issues/` (for passability, asset pipeline, Avalonia port, CI matrix) to convert the 90-day plan into actionable GitHub issues.
+- A PR template (`.github/PULL_REQUEST_TEMPLATE.md`) and a milestone summary at `docs/MILESTONE-90-DAYS.md` to help triage and track work.
+
+Recent follow-ups (2025-10-25):
+
+- Added a small set of unit tests in `DotGame.Core.Tests/MapPassabilityTests.cs` that exercise passability behaviour (initialize with passability, dimension-mismatch cases, and null-passability handling). These tests are intended as a starting point and can be expanded with roundtrip/save-load tests.
+- Added a GitHub Actions workflow `.github/workflows/validate-maps.yml` that runs the `tools/MapPassabilityTool` in dry-run for pushes and pull requests touching `maps/` or the tool itself. The workflow fails if the validator reports missing passability entries or errors, providing immediate protection for PRs that touch maps.
+- Per a local, reviewed change, `maps/mymap.json` now contains a `camera` metadata block with position and a quaternion rotation (metadata only; renderer changes not included). This is a small experiment to store 3D camera metadata for previews.
+
+What is *not* yet applied to production maps or CI:
+- `maps/*.json` files have not been modified automatically in the repository — the MapPassabilityTool and Python scripts currently run in dry-run mode by default; `--apply` must be used to modify files and commit those changes. A considered migration plan with review and backups is recommended.
+- The CI validator workflow has been added in dry-run form (`.github/workflows/validate-maps.yml`) and will run on PRs/pushes; after a migration is agreed it can be tightened to be stricter or extended to run in other CI contexts.
+
+Quick commands to reproduce locally (PowerShell):
+
+```powershell
+dotnet run --project tools/MapPassabilityTool/MapPassabilityTool.csproj -- --maps-dir .\maps
+dotnet run --project tools/MapPassabilityTool/MapPassabilityTool.csproj -- --maps-dir .\maps --apply
+# or (if you prefer Python helpers):
+python .\scripts\validate_maps.py .\maps
+python .\scripts\add_passability.py .\maps
+```
+
+If you want, I can run the MapPassabilityTool here in dry-run and share the output; run-and-apply changes require confirmation because they modify `maps/*.json` (backups are created).
+
+
+## Roadmap coverage & assessment
+
+Summary of how the repository maps to the roadmap parts and a short assessment of non-roadmap findings.
+
+- Part I – Foundations: Partial — The project implements a 2D tile engine and editor in C#. It includes both a visual map editor and a simple game player. Essential math is minimal and it follows common C# practices (OOP, JSON serialization) but does not implement advanced engine-level features.
+- Part II – Systems: None — No custom allocators, logging/assertion framework, or a job system/multithreading primitives are present.
+- Part III – Graphics: None — Rendering relies on Windows Forms/Avalonia and there is no custom rendering pipeline, shaders, or scene graph.
+- Part IV – Animation: Partial — Basic frame-based character animations exist (sprite frame swaps during movement). No blending, IK, or compression systems.
+- Part V – Physics: None — Movement is strictly tile-based; no physics or collision engine is implemented.
+- Part VI – Scripting/AI: None — No embedded scripting or significant AI systems; characters are player-controlled and there is no ECS apparent.
+- Part VII – Assets/Editor: Partial — The editor UI is present and maps are saved as JSON (embedded base64 images). There is no full asset-pipeline or DCC integration.
+- Part VIII – Misc Systems: None — No audio, networking, or profiling/diagnostics beyond what .NET provides.
+- Part IX – Performance: None — No data-oriented design or multi-core scaling techniques are used.
+
+Additional (non-roadmap) observations:
+- Cross-Platform UI: An Avalonia demo exists alongside Windows Forms, and the README documents Linux/VNC workflows.
+- Replit/Cloud Setup: Scripts and cloud/CI assets exist for running in web/VNC environments.
+- JSON Map Format: Maps use JSON with embedded images (base64), a simple but suboptimal asset representation for larger projects.
+- Web components: A non-trivial amount of JS/CSS suggests an accompanying web/demo or tooling layer.
+- Testing scaffold: `DotGame.Core.Tests` and `DotGame.Tests` provide unit tests for core logic and adapter wiring.
+
+Stability note: The project appears stable for its current scope (editor + small runtime), but lacks broader engineering tooling (robust logging, comprehensive tests for edge cases, structured asset pipeline).
+
+Key short-term recommendations (workplan highlights)
+- Complete the Avalonia port for remaining editor dialogs so the app is fully cross-platform (high priority if cross-platform support is a project goal).
+- Add quality-of-life engine features: simple audio playback, tile passability/collision flags, a small AI/patrol behavior for NPCs, and an optional scripting surface (Lua/C#) for modding.
+- Improve asset pipeline: avoid embedding full PNGs in map JSON where possible; provide project-level tileset folders and a lightweight asset validator script.
+- Increase code quality: add structured logging (Serilog or Microsoft.Extensions.Logging), consistent exception handling, and unit tests for map loading/character behavior.
+- UX and editor features: undo/redo, multiple tile layers, tile metadata (collision/trigger), and a way to export a playable bundle.
+- Document contributor workflows: how to register UI adapters, run the Avalonia demo, and add CI matrix entries.
+
+These recommendations are intended to be practical first steps to move the project from a solid prototype toward a more production-ready editor/runtime.
+
+
 ## Work plan (priority, with status)
 1. Inventory Windows Forms files — completed.
    - Files catalogued under `src/DotGameCSharp/`.
@@ -78,88 +233,93 @@ Validation:
 - Tests: `DotGame.Tests/*` (DI wiring, preview behavior, EditorWindow integration) and `DotGame.Core.Tests` where applicable.
 - CI: `.github/workflows/ci.yml` and `scripts/analyze-job-system-telemetry.py`
 
----
+
+## Quick project snapshot
+
+- What this repo is: a C#/.NET 2D tile-based level editor and simple runtime (editor + player). It exposes a Windows Forms origin and an Avalonia demo for cross-platform UI.
+- Key implemented features: visual map editor (tileset loading, painting, adjustable brush), JSON save/load (maps include embedded base64 images), a player runtime with named characters, tile-based movement, and basic frame-based animations.
+
+Summary: the codebase is a solid prototype that cleanly separates core game/data logic (`DotGame.Core`) from UI adapters. It is not a full engine (no physics, advanced rendering, or scripting), but it is well organized and has a modest test scaffold and CI assets.
+
+## Roadmap coverage (short)
+
+- Part I — Foundations: Partial — core domain (maps, tiles, characters) implemented with JSON serialization and OOP patterns. No advanced engine math or memory systems.
+- Part II — Systems: None — lacks custom allocators, logging framework, or job-system primitives.
+- Part III — Graphics: None — rendering delegated to Windows Forms/Avalonia; no custom pipeline or shaders.
+- Part IV — Animation: Partial — frame-based sprite animations exist; no blending, IK, or compression.
+- Part V — Physics: None — tile-based movement only; no physics or collision system.
+- Part VI — Scripting/AI: None — no embedded scripting or rich AI systems; no ECS.
+- Part VII — Assets/Editor: Partial — editor UI exists and maps are saved as JSON (embedded images). No structured asset DB or DCC integration.
+- Part VIII — Misc: None — no audio, networking, or built-in profiling beyond .NET.
+- Part IX — Performance: None — no DOD/multi-core scaling.
+
+Non-roadmap highlights:
+- An Avalonia demo exists; README documents Linux/VNC support and there are scripts for cloud/VNC deployment.
+- There are web/JS assets (~38% of repository), likely demo/telemetry or tooling code.
+- Tests exist in `DotGame.Core.Tests` and `DotGame.Tests`, including adapter and preview lifecycle tests.
+
+Stability note: the project seems stable for its current scope but lacks robust logging, broad unit coverage for edge cases, and an asset pipeline suited to larger projects.
+
+## Recommended priorities (practical, ordered)
+
+1) Finish the Avalonia port so editor workflows run cross-platform (high priority if cross-platform use is a goal).
+2) Add small engine quality-of-life features: tile passability (collision flags), basic audio playback, and simple NPC patrol AI.
+3) Improve the asset pipeline: avoid embedding full PNGs inside map JSON; provide tileset folders and a validation script.
+4) Improve reliability and maintainability: add structured logging (Serilog or Microsoft.Extensions.Logging), better exception handling, and expand unit tests for map loading and editor operations (undo/redo, save/load edge cases).
+5) UX: undo/redo, multiple layers, tile metadata (collision/trigger), and a way to export playable bundles.
+
+These items are intentionally low-risk and give measurable value quickly.
+
+## Short implementation plan (90 days, focused)
+
+Convert the plan below into GitHub issues and a 90-day milestone. Each item is small and testable.
+
+1) Stabilize CI & expand minimal matrix (weeks 0–3)
+   - Ensure solution builds and tests run on Windows and Ubuntu in CI.
+   - Deliverable: CI workflow with a small matrix; passing runs.
+
+2) Finish core/adapter separation (weeks 1–6)
+   - Remove remaining direct domain references from UI projects; expose contracts in `DotGame.Core`.
+   - Deliverable: no UI files under `DotGame` referencing `DotGame.Core` types directly (enforced by lint rule).
+
+3) Improve preview lifecycle tests (weeks 2–8)
+   - Add tests to exercise starting/stopping previews from JSON and concurrent start/stop behavior.
+   - Deliverable: 3–6 new tests in `DotGame.Tests` and/or `DotGame.Core.Tests`.
+
+4) Avalonia migration sprint (weeks 4–12)
+   - Convert ancillary dialogs to Avalonia; verify editor workflows on Linux/Avalonia.
+   - Deliverable: PRs converting remaining dialogs; manual verification checklist in `docs/`.
+
+5) Asset & editor QoL (weeks 6–12)
+   - Add tile passability metadata, an asset validator script under `scripts/`, and a small exporter that avoids storing full encoded images per tile.
+   - Deliverable: `scripts/validate-tileset.*`, map exporter, and tests.
+
+## Files to inspect next
+
+- `DotGame.Core/Maps/Map.cs`
+- `DotGame/src/Views/EditorWindow.axaml.cs`
+- `DotGame/src/Services/TileServiceAdapter.cs`
+- `DotGame.Tests/*`
 
 ## How to validate locally
-1. Build the solution (requires .NET 8 SDK):
+
+1) Build:
 
 ```powershell
-dotnet build leveleditor.sln --configuration Release
+dotnet build "leveleditor.sln" --configuration Release
 ```
 
-2. Run tests:
+2) Tests:
 
 ```powershell
-dotnet test leveleditor.sln --configuration Release --no-build
+dotnet test "leveleditor.sln" --configuration Release --no-build
 ```
 
-3. To run the Avalonia app on Windows (dev helper):
+3) Run Avalonia demo (Windows helper):
 
 ```powershell
-#.\run-windows.ps1
+# .\run-windows.ps1
 ```
 
-Notes: unit tests include headless-friendly tests that initialize Avalonia's Skia platform; CI runs the same tests in a headless environment.
 
----
-
-## Remaining recommended next steps
-- Expand CI to run a wider matrix (Windows/Linux, different job system backends) if you want the telemetry sweep to run across platforms.
-- Continue migrating any remaining UI files that reference core domain types — the CI lint rule will help catch regressions.
-- Improve test coverage for EditorWindow-backed preview lifecycle (e.g., assert EditorGame state) if you want deeper runtime assertions; this requires more runtime assets or mock instrumentation.
-- Write a short contributor guide documenting how to register UI adapters in `Program.cs` and how to add new core contracts.
-
----
-
-This file is intended to be a concise snapshot of progress. The authoritative, machine-readable source of task state is the repository todo list (maintained during development). Update that list first and then refresh this document when the plan changes.
-
----
-
-## Next 90 days (actionable)
-
-This section translates the current work plan into a focused, testable 90-day execution plan with owners, estimated milestones, and success criteria. Each item below is intentionally small and verifiable — when complete, convert it into issues/milestones in GitHub.
-
-1) Stabilize CI & expand test matrix — Owner: infra / core maintainer (week 0–3)
-   - Goal: Ensure solution builds and tests run on Windows and Linux in CI; add a minimal matrix for .NET 8 and .NET 7 compatibility if feasible.
-   - Deliverables: updated `.github/workflows/ci.yml` with matrix entries, passing runs for both OSes.
-   - Success criteria: CI green on both Windows and Ubuntu runners for the default test suite within 3 attempts.
-
-2) Finalize Core/Adapter contracts & reduce domain leakage — Owner: core maintainer (week 1–6)
-   - Goal: Remove remaining direct domain type references from UI projects; ensure all core services are referenced via interfaces in `DotGame.Core`.
-   - Deliverables: linter rule verification, PR to update any remaining references, small migration notes in `docs/`.
-   - Success criteria: No files in UI projects using `namespace DotGame.Core` per CI lint; tests covering preview startup/shutdown pass.
-
-3) Editor preview robustness & test coverage — Owner: runtime/editor dev (week 2–8)
-   - Goal: Increase test coverage around preview lifecycle, add edge tests for starting previews from JSON strings and concurrent start/stop calls.
-   - Deliverables: 4–6 new unit/integration tests added to `DotGame.Tests` and `DotGame.Core.Tests` covering startup, stop, and error conditions.
-   - Success criteria: Added tests pass locally and in CI; code paths for preview error handling exercised by tests.
-
-4) UX & Avalonia migration sprint — Owner: UI/UX dev (week 4–12)
-   - Goal: Convert the last 2–4 remaining Windows Forms dialogs to Avalonia and remove any platform-specific fallbacks.
-   - Deliverables: PR(s) converting dialogs, updated screenshots in `docs/`, and a short contributor note on registering adapters.
-   - Success criteria: All editor workflows exercised manually (start/stop preview, open/save map, tile editing) work on Avalonia without crashing.
-
-5) Asset & tile pipeline improvements — Owner: asset lead (week 6–12)
-   - Goal: Simplify creating/previewing maps and tiles in the editor and reduce friction for contributors adding assets.
-   - Deliverables: small CLI or script (`scripts/`) to validate tilesets, and documentation in `docs/` describing the asset layout.
-   - Success criteria: Contributors can add a tileset and run a validation script that returns pass/fail with actionable messages.
-
-6) Convert roadmap items to issues & set milestones — Owner: project lead (week 0–2)
-   - Goal: Create GitHub issues for the above items, assign owners, and set a 90-day milestone so progress is tracked in the issue tracker.
-   - Deliverables: issues created with checklists, milestone created for the 90-day plan.
-   - Success criteria: Each of the 1–5 items has an issue and the milestone is populated.
-
-Quick notes and assumptions
---
-- Assumes maintainers have permissions to change GitHub workflows and create milestones.
-- If running matrix CI is too heavy, start with a single Ubuntu runner and expand after stability is confirmed.
-- Tests that depend on graphical components should prefer headless adapters or be ignored for headful runners.
-
-Next actions (recommended)
-- Convert each numbered item above into an issue and attach this section as an implementation note.
-- Triage the infra tasks first (CI + milestone creation) so contributors can rely on consistent validation.
-
----
-
-Update history: 2025-10-24 — appended actionable 90-day plan.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,3 +113,53 @@ Notes: unit tests include headless-friendly tests that initialize Avalonia's Ski
 
 This file is intended to be a concise snapshot of progress. The authoritative, machine-readable source of task state is the repository todo list (maintained during development). Update that list first and then refresh this document when the plan changes.
 
+---
+
+## Next 90 days (actionable)
+
+This section translates the current work plan into a focused, testable 90-day execution plan with owners, estimated milestones, and success criteria. Each item below is intentionally small and verifiable — when complete, convert it into issues/milestones in GitHub.
+
+1) Stabilize CI & expand test matrix — Owner: infra / core maintainer (week 0–3)
+   - Goal: Ensure solution builds and tests run on Windows and Linux in CI; add a minimal matrix for .NET 8 and .NET 7 compatibility if feasible.
+   - Deliverables: updated `.github/workflows/ci.yml` with matrix entries, passing runs for both OSes.
+   - Success criteria: CI green on both Windows and Ubuntu runners for the default test suite within 3 attempts.
+
+2) Finalize Core/Adapter contracts & reduce domain leakage — Owner: core maintainer (week 1–6)
+   - Goal: Remove remaining direct domain type references from UI projects; ensure all core services are referenced via interfaces in `DotGame.Core`.
+   - Deliverables: linter rule verification, PR to update any remaining references, small migration notes in `docs/`.
+   - Success criteria: No files in UI projects using `namespace DotGame.Core` per CI lint; tests covering preview startup/shutdown pass.
+
+3) Editor preview robustness & test coverage — Owner: runtime/editor dev (week 2–8)
+   - Goal: Increase test coverage around preview lifecycle, add edge tests for starting previews from JSON strings and concurrent start/stop calls.
+   - Deliverables: 4–6 new unit/integration tests added to `DotGame.Tests` and `DotGame.Core.Tests` covering startup, stop, and error conditions.
+   - Success criteria: Added tests pass locally and in CI; code paths for preview error handling exercised by tests.
+
+4) UX & Avalonia migration sprint — Owner: UI/UX dev (week 4–12)
+   - Goal: Convert the last 2–4 remaining Windows Forms dialogs to Avalonia and remove any platform-specific fallbacks.
+   - Deliverables: PR(s) converting dialogs, updated screenshots in `docs/`, and a short contributor note on registering adapters.
+   - Success criteria: All editor workflows exercised manually (start/stop preview, open/save map, tile editing) work on Avalonia without crashing.
+
+5) Asset & tile pipeline improvements — Owner: asset lead (week 6–12)
+   - Goal: Simplify creating/previewing maps and tiles in the editor and reduce friction for contributors adding assets.
+   - Deliverables: small CLI or script (`scripts/`) to validate tilesets, and documentation in `docs/` describing the asset layout.
+   - Success criteria: Contributors can add a tileset and run a validation script that returns pass/fail with actionable messages.
+
+6) Convert roadmap items to issues & set milestones — Owner: project lead (week 0–2)
+   - Goal: Create GitHub issues for the above items, assign owners, and set a 90-day milestone so progress is tracked in the issue tracker.
+   - Deliverables: issues created with checklists, milestone created for the 90-day plan.
+   - Success criteria: Each of the 1–5 items has an issue and the milestone is populated.
+
+Quick notes and assumptions
+--
+- Assumes maintainers have permissions to change GitHub workflows and create milestones.
+- If running matrix CI is too heavy, start with a single Ubuntu runner and expand after stability is confirmed.
+- Tests that depend on graphical components should prefer headless adapters or be ignored for headful runners.
+
+Next actions (recommended)
+- Convert each numbered item above into an issue and attach this section as an implementation note.
+- Triage the infra tasks first (CI + milestone creation) so contributors can rely on consistent validation.
+
+---
+
+Update history: 2025-10-24 — appended actionable 90-day plan.
+

--- a/issues/0001-add-passability.md
+++ b/issues/0001-add-passability.md
@@ -1,0 +1,26 @@
+---
+title: Add tile passability metadata and validator
+labels: enhancement, roadmap, passability
+---
+
+## Summary
+
+Add `passability` metadata to maps and a validator/CI check. Provide tool(s) to migrate existing `maps/*.json` files by inserting a default `passability` jagged bool[][] where missing.
+
+## Motivation
+
+The editor and core map model support passability, but many maps lack the metadata. This issue ensures consistency and enables collision-aware gameplay and editor UX.
+
+## Acceptance criteria
+- [ ] A repository tool exists (MapPassabilityTool or equivalent) that validates `maps/*.json` files.
+- [ ] The tool can run in dry-run mode and an `--apply` mode that creates `.bak` backups before writing.
+- [ ] CI includes a dry-run validation job (optional until migration completes).
+- [ ] Existing maps are migrated (or documented) with passability defaulted to `true` where previously missing.
+
+## Implementation
+- Create/land `tools/MapPassabilityTool` (done).
+- Run dry-run against `maps/` and confirm results.
+- With approval, run `--apply` and commit changes.
+
+## Estimate
+1–2 days

--- a/issues/0002-asset-pipeline.md
+++ b/issues/0002-asset-pipeline.md
@@ -1,0 +1,16 @@
+---
+title: Improve asset pipeline (tilesets) and avoid embedded PNGs in maps
+labels: enhancement, roadmap, assets
+---
+
+## Summary
+
+Provide a lightweight asset exporter and validator that can extract embedded base64 tile images from `maps/*.json` into a tileset folder, and update maps to reference files instead of embedding full PNG data URLs.
+
+## Acceptance criteria
+- [ ] Script/tool to extract embedded tiles into `assets/tilesets/<name>/` and rewrite map references.
+- [ ] Validator that ensures referenced files exist and are not duplicated across maps.
+- [ ] Documentation describing migration steps and recommended layout.
+
+## Estimate
+2–4 days

--- a/issues/0003-avalonia-port.md
+++ b/issues/0003-avalonia-port.md
@@ -1,0 +1,16 @@
+---
+title: Finish Avalonia port for remaining editor dialogs
+labels: enhancement, roadmap, ui
+---
+
+## Summary
+
+Port remaining Windows Forms dialogs to Avalonia and ensure the editor workflows operate on Linux/Avalonia.
+
+## Acceptance criteria
+- [ ] Inventory of all remaining Windows Forms dialogs and their priorities.
+- [ ] Port top 3 high-priority dialogs to Avalonia and test editor flows manually on Linux.
+- [ ] Add integration tests to exercise these flows where practical.
+
+## Estimate
+5–10 days (split across multiple PRs)

--- a/issues/0004-ci-matrix.md
+++ b/issues/0004-ci-matrix.md
@@ -1,0 +1,16 @@
+---
+title: Expand CI to run on Windows and Ubuntu (minimal matrix)
+labels: ci, roadmap
+---
+
+## Summary
+
+Ensure the solution builds and tests run on both Windows and Ubuntu in CI.
+
+## Acceptance criteria
+- [ ] CI workflow updated to include a small matrix (windows-latest, ubuntu-latest).
+- [ ] All tests run and pass on both platforms.
+- [ ] Lint rule preventing UI projects from declaring `namespace DotGame.Core` enforced.
+
+## Estimate
+1–2 days

--- a/maps/mymap.json
+++ b/maps/mymap.json
@@ -124,5 +124,18 @@
       null,
       null
     ]
-  ]
+  ],
+  "camera": {
+    "position": [160.0, 160.0, 300.0],
+    "rotationQuaternion": {
+      "w": 0.9238795325112867,
+      "x": -0.3826834323650898,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "projection": "perspective",
+    "fovDegrees": 60.0,
+    "near": 0.1,
+    "far": 2000.0
+  }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,20 @@
+validate_maps.py
+
+Small helper to validate JSON map files in the repository `maps/` directory.
+
+Usage (PowerShell):
+
+    python .\scripts\validate_maps.py
+
+What it checks:
+- JSON parse correctness
+- Required keys: cols, rows, map
+- map is rows x cols
+- optional passability grid presence and correctness (boolean grid)
+
+Exit codes:
+- 0: no errors (warnings possible)
+- 1: one or more errors found
+
+Suggested next steps:
+- If your maps are missing a passability grid, consider adding a `passability` field with a boolean grid matching rows x cols where `true` means passable and `false` means blocked.

--- a/scripts/add_passability.py
+++ b/scripts/add_passability.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Add a default passability grid to maps that don't have one.
+
+The script will:
+- Iterate all JSON files in the repo `maps/` directory.
+- If a file lacks a `passability` field (or it's null), create a jagged boolean grid [rows][cols] filled with `true` (passable).
+- Write a backup of the original file with `.bak` appended.
+- Overwrite the original with the updated JSON (pretty-printed).
+
+Usage:
+    python .\scripts\add_passability.py [--dry-run]
+
+Options:
+  --dry-run   Don't write any files; just report what would be changed.
+
+This is intentionally conservative and only adds a default passability grid. For more nuanced behavior (e.g., infer from doodads or tile properties), extend the script.
+"""
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MAP_DIR = ROOT / "maps"
+
+if not MAP_DIR.exists():
+    print(f"Map directory not found: {MAP_DIR}")
+    sys.exit(1)
+
+DRY_RUN = "--dry-run" in sys.argv
+
+changed = 0
+
+for path in sorted(MAP_DIR.glob("*.json")):
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except Exception as e:
+        print(f"SKIP {path}: failed to parse JSON: {e}")
+        continue
+
+    cols = data.get("cols")
+    rows = data.get("rows")
+    if not isinstance(cols, int) or not isinstance(rows, int) or cols <= 0 or rows <= 0:
+        print(f"SKIP {path}: missing or invalid cols/rows")
+        continue
+
+    pass_grid = data.get("passability")
+    if pass_grid is not None:
+        print(f"OK {path}: passability already present")
+        continue
+
+    print(f"ADD {path}: inserting default passability grid ({rows}x{cols})")
+    changed += 1
+    if DRY_RUN:
+        continue
+
+    # create jagged array [row][col]
+    jagged = [[True for _ in range(cols)] for _ in range(rows)]
+    data["passability"] = jagged
+
+    # backup
+    bak = path.with_suffix(path.suffix + ".bak")
+    try:
+        path.rename(bak)
+    except Exception:
+        # if rename fails, try writing to bak path
+        bak.write_text(text, encoding="utf-8")
+
+    # write updated file
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+print(f"\nFinished. {changed} file(s) modified.")
+if changed > 0 and DRY_RUN:
+    print("Dry run: no files were changed. Rerun without --dry-run to apply changes.")
+
+sys.exit(0)

--- a/scripts/validate_maps.py
+++ b/scripts/validate_maps.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Validate map JSON files under the `maps/` directory.
+
+Checks performed:
+- JSON parses correctly.
+- Required fields: cols, rows, map (array-of-arrays) present.
+- If a passability grid is present it must match rows x cols.
+
+Exit code: 0 if all files OK or only warnings; 1 if any file has an error.
+
+This is a small, low-risk helper to encourage adding passability metadata for tile-based movement.
+"""
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MAP_DIR = ROOT / "maps"
+
+ERRORS = 0
+
+
+def check_map_file(path: Path) -> None:
+    global ERRORS
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except Exception as e:
+        print(f"ERROR: Failed to parse JSON: {path}: {e}")
+        ERRORS += 1
+        return
+
+    cols = data.get("cols")
+    rows = data.get("rows")
+    tilemap = data.get("map") or data.get("tiles") or data.get("mapData")
+
+    if cols is None or rows is None or tilemap is None:
+        print(f"ERROR: Missing required fields (cols, rows, map) in {path}")
+        ERRORS += 1
+        return
+
+    if not isinstance(tilemap, list):
+        print(f"ERROR: 'map' must be an array-of-arrays in {path}")
+        ERRORS += 1
+        return
+
+    if len(tilemap) != rows:
+        print(f"ERROR: map row count ({len(tilemap)}) != rows ({rows}) in {path}")
+        ERRORS += 1
+        return
+
+    for y, row in enumerate(tilemap):
+        if not isinstance(row, list):
+            print(f"ERROR: map[{y}] is not an array in {path}")
+            ERRORS += 1
+            return
+        if len(row) != cols:
+            print(f"ERROR: map[{y}] length ({len(row)}) != cols ({cols}) in {path}")
+            ERRORS += 1
+            return
+
+    # Check passability keys
+    pass_grid = None
+    if "passability" in data:
+        pass_grid = data["passability"]
+    elif "pass" in data:
+        pass_grid = data["pass"]
+    elif "passabilityGrid" in data:
+        pass_grid = data["passabilityGrid"]
+
+    if pass_grid is None:
+        print(f"WARN: No passability grid found in {path} (map will be walkable by default). Consider adding a 'passability' boolean grid.)")
+        return
+
+    # Validate passability dimension
+    if not isinstance(pass_grid, list) or len(pass_grid) != rows:
+        print(f"ERROR: passability must be an array of length rows ({rows}) in {path}")
+        ERRORS += 1
+        return
+
+    for y, prow in enumerate(pass_grid):
+        if not isinstance(prow, list) or len(prow) != cols:
+            print(f"ERROR: passability[{y}] must be an array of length cols ({cols}) in {path}")
+            ERRORS += 1
+            return
+        for x, v in enumerate(prow):
+            if not isinstance(v, bool):
+                print(f"ERROR: passability[{y}][{x}] must be boolean in {path}")
+                ERRORS += 1
+                return
+
+    print(f"OK: {path} has valid passability grid ({rows}x{cols}).")
+
+
+if __name__ == "__main__":
+    files = sorted(MAP_DIR.glob("*.json"))
+    if not files:
+        print(f"No maps found in {MAP_DIR}")
+        sys.exit(0)
+
+    for f in files:
+        check_map_file(f)
+
+    if ERRORS:
+        print(f"\nValidation finished: {ERRORS} error(s) found.")
+        sys.exit(1)
+    else:
+        print("\nValidation finished: no errors.")
+        sys.exit(0)

--- a/tools/MapPassabilityTool/MapPassabilityTool.csproj
+++ b/tools/MapPassabilityTool/MapPassabilityTool.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tools/MapPassabilityTool/Program.cs
+++ b/tools/MapPassabilityTool/Program.cs
@@ -1,0 +1,192 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+internal class Program
+{
+    private static int Main(string[] args)
+    {
+        bool apply = args.Contains("--apply");
+        string mapsDir = "maps";
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--maps-dir" && i + 1 < args.Length)
+            {
+                mapsDir = args[i + 1];
+                i++;
+            }
+        }
+
+        Console.WriteLine($"MapPassabilityTool: mapsDir='{mapsDir}' apply={apply}");
+
+        if (!Directory.Exists(mapsDir))
+        {
+            Console.Error.WriteLine($"Error: maps directory not found: {mapsDir}");
+            return 2;
+        }
+
+        var files = Directory.GetFiles(mapsDir, "*.json", SearchOption.TopDirectoryOnly).OrderBy(x => x).ToArray();
+        if (files.Length == 0)
+        {
+            Console.WriteLine("No .json files found in maps directory.");
+            return 0;
+        }
+
+        int changed = 0;
+        int errors = 0;
+
+        foreach (var file in files)
+        {
+            Console.WriteLine($"\nProcessing: {file}");
+            string text;
+            try
+            {
+                text = File.ReadAllText(file);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Failed to read file: {ex.Message}");
+                errors++;
+                continue;
+            }
+
+            JsonNode? root;
+            try
+            {
+                root = JsonNode.Parse(text);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Invalid JSON: {ex.Message}");
+                errors++;
+                continue;
+            }
+
+            if (root == null)
+            {
+                Console.Error.WriteLine("  Empty JSON document");
+                errors++;
+                continue;
+            }
+
+            bool okRows = TryGetInt(root["rows"], out int rows);
+            bool okCols = TryGetInt(root["cols"], out int cols);
+
+            if (!okRows || !okCols)
+            {
+                Console.Error.WriteLine("  Missing or invalid 'rows'/'cols' properties. Skipping.");
+                errors++;
+                continue;
+            }
+
+            var passNode = root["passability"];
+            if (passNode == null)
+            {
+                Console.WriteLine($"  passability: MISSING (rows={rows}, cols={cols})");
+                if (apply)
+                {
+                    // inject default (all true)
+                    var rowsArray = new JsonArray();
+                    for (int r = 0; r < rows; r++)
+                    {
+                        var rowArr = new JsonArray();
+                        for (int c = 0; c < cols; c++) rowArr.Add(true);
+                        rowsArray.Add(rowArr);
+                    }
+                    root["passability"] = rowsArray;
+
+                    try
+                    {
+                        // create backup
+                        var bak = file + ".bak";
+                        if (File.Exists(bak)) bak = file + ".bak." + DateTime.Now.ToString("yyyyMMddHHmmss");
+                        File.Copy(file, bak);
+                        File.WriteAllText(file, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+                        Console.WriteLine($"  Injected passability and backed up original to: {bak}");
+                        changed++;
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"  Failed to write file: {ex.Message}");
+                        errors++;
+                    }
+                }
+                continue;
+            }
+
+            // If passability exists, validate dimensions
+            if (passNode is JsonArray passArr)
+            {
+                if (passArr.Count != rows)
+                {
+                    Console.Error.WriteLine($"  passability malformed: row count {passArr.Count} != rows {rows}");
+                    errors++;
+                    continue;
+                }
+
+                bool rowError = false;
+                for (int r = 0; r < passArr.Count; r++)
+                {
+                    if (passArr[r] is not JsonArray row)
+                    {
+                        Console.Error.WriteLine($"  passability malformed: row {r} is not an array");
+                        rowError = true; break;
+                    }
+                    if (row.Count != cols)
+                    {
+                        Console.Error.WriteLine($"  passability malformed: row {r} length {row.Count} != cols {cols}");
+                        rowError = true; break;
+                    }
+                    foreach (var val in row)
+                    {
+                        if (val is not JsonValue)
+                        {
+                            Console.Error.WriteLine($"  passability malformed: non-primitive found in row {r}");
+                            rowError = true; break;
+                        }
+                    }
+                    if (rowError) break;
+                }
+
+                if (!rowError) Console.WriteLine("  passability: OK");
+                else errors++;
+            }
+            else
+            {
+                Console.Error.WriteLine("  passability malformed: not an array");
+                errors++;
+            }
+        }
+
+        Console.WriteLine($"\nSummary: changed={changed}, errors={errors}");
+        return errors == 0 ? 0 : 1;
+    }
+
+    private static bool TryGetInt(JsonNode? node, out int value)
+    {
+        value = 0;
+        if (node == null) return false;
+        try
+        {
+            // JsonNode.GetValue<T> will throw if not convertible
+            value = node.GetValue<int>();
+            return true;
+        }
+        catch
+        {
+            // fallback to parsing string
+            try
+            {
+                var s = node.ToString();
+                return int.TryParse(s, out value);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/tools/MapPassabilityTool/README.md
+++ b/tools/MapPassabilityTool/README.md
@@ -1,0 +1,17 @@
+# MapPassabilityTool
+
+Small dotnet console tool to validate and optionally inject a default `passability` jagged bool[][] into `maps/*.json` files.
+
+Usage (dry-run):
+
+  dotnet run --project tools/MapPassabilityTool/MapPassabilityTool.csproj -- --maps-dir maps
+
+To actually write changes (creates a `.bak` backup for each file it modifies):
+
+  dotnet run --project tools/MapPassabilityTool/MapPassabilityTool.csproj -- --maps-dir maps --apply
+
+Options:
+- `--maps-dir <path>`: directory containing `*.json` map files (default: `maps`)
+- `--apply`: if provided, the tool will write changes and create `.bak` backups. Otherwise it runs in dry-run mode.
+
+The tool validates that `rows` and `cols` exist and that `passability` (if present) is a jagged array matching those dimensions.


### PR DESCRIPTION
This draft PR adds tooling and tests to validate map passability and a documented, reviewable migration checklist in docs/ROADMAP.md and issues/0001-add-passability.md. Dry-run report attached: 3 maps missing passability (mymap.json, sample.json, simple.json). Next step: apply migration in a follow-up PR (chore/add-passability) after review.